### PR TITLE
Converting fontawesome to https CDN, removing test css

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
       ],
       "css": [
         "src/css/normalize.css",
-        "src/css/font-awesome.min.css",
+        "src/css/font-awesome.css",
         "src/css/foundation.prefixed.css",
         "src/inject/inject.css",
         "src/css/styles.css"

--- a/src/css/font-awesome.css
+++ b/src/css/font-awesome.css
@@ -1,13 +1,15 @@
 /*!
- *  Font Awesome 4.2.0 by @davegandy - http://fontawesome.io - @fontawesome
- *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
+ *  Font Awesome 4.2.0 by @davegandy - https://fontawesome.io - @fontawesome
+ *  License - https://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
 /* FONT PATH
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../fonts/fontawesome-webfont.eot?v=4.2.0');
-  src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.2.0') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff?v=4.2.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.2.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular') format('svg');
+  /*src: url('../fonts/fontawesome-webfont.eot?v=4.2.0');*/
+  /*src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.2.0') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff?v=4.2.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.2.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular') format('svg');*/
+  src: url('https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/fonts/fontawesome-webfont.eot?v=4.2.0');
+  src: url('https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/fonts/fontawesome-webfont.eot?#iefix&v=4.2.0') format('embedded-opentype'), url('https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/fonts/fontawesome-webfont.woff?v=4.2.0') format('woff'), url('https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/fonts/fontawesome-webfont.ttf?v=4.2.0') format('truetype'), url('https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -164,6 +164,3 @@ th:hover i.column-sort{
   opacity: 0.9;
   background: rgba(0,0,0,0.1)
 }
-.eric-testing{
-  display: block;
-}


### PR DESCRIPTION
A fresh install produced 404 errors on .woff and .eot files, thus breaking icon support. These 404's are produced by a server misconfiguration - a new mime type needs to be added to IIS in order for local font files to be served properly... unfortunately, sysadmin refuses to make this change. font-awesome was changed to the unminified version in the manifest and the actual font files were linked out to the secure CDN and now the fonts load.

Also removed test css silliness.
